### PR TITLE
Fix `Esc` going to jlab-command mode

### DIFF
--- a/History.md
+++ b/History.md
@@ -3,6 +3,7 @@
 ## Next
 
   * Homogenize the project with the jupyterlab-contrib organization (#46)
+  * Fix `Esc` being override by the shortcuts extensions in jupyterlab
 
 ## 0.14.0 / 2021-05-04
 

--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -1,14 +1,22 @@
 {
-    "title": "Notebook Vim",
-    "description": "Notebook Vim Settings",
-    "type": "object",
-    "additionalProperties": true,
-    "properties": {
-      "enabled": {
-        "type": "boolean",
-        "title": "Enabled",
-        "description": "Enable/disable notebook vim (may require a page refresh)",
-        "default": true
-      }
+  "title": "Notebook Vim",
+  "description": "Notebook Vim Settings",
+  "type": "object",
+  "additionalProperties": true,
+  "jupyter.lab.shortcuts": [
+    {
+      "command": "notebook:enter-command-mode",
+      "keys": ["Escape"],
+      "selector": ".jp-Notebook.jp-mod-editMode",
+      "disabled": true
     }
+  ],
+  "properties": {
+    "enabled": {
+      "type": "boolean",
+      "title": "Enabled",
+      "description": "Enable/disable notebook vim (may require a page refresh)",
+      "default": true
+    }
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ import { ISettingRegistry } from '@jupyterlab/settingregistry';
 import { ReadonlyPartialJSONObject } from '@lumino/coreutils';
 
 import { ElementExt } from '@lumino/domutils';
+import { IDisposable } from '@lumino/disposable';
 
 /**
  * A boolean indicating whether the platform is Mac.
@@ -673,14 +674,16 @@ function activateCellVim(
   settingRegistry: ISettingRegistry
 ): Promise<void> {
   let hasEverBeenEnabled = false;
+  let escBinding: IDisposable | null = null;
   function updateSettings(settings: ISettingRegistry.ISettings): void {
     // TODO: This does not reset any cells that have been used with VIM
     enabled = settings.get('enabled').composite === true;
     if (enabled && !hasEverBeenEnabled) {
       hasEverBeenEnabled = true;
       setupPlugin(app, tracker, jlabCodeMirror);
+      escBinding?.dispose();
     } else if (!enabled) {
-      app.commands.addKeyBinding({
+      escBinding = app.commands.addKeyBinding({
         command: 'notebook:enter-command-mode',
         keys: ['Escape'],
         selector: '.jp-Notebook.jp-mod-editMode'

--- a/src/index.ts
+++ b/src/index.ts
@@ -679,6 +679,12 @@ function activateCellVim(
     if (enabled && !hasEverBeenEnabled) {
       hasEverBeenEnabled = true;
       setupPlugin(app, tracker, jlabCodeMirror);
+    } else if (!enabled) {
+      app.commands.addKeyBinding({
+        command: 'notebook:enter-command-mode',
+        keys: ['Escape'],
+        selector: '.jp-Notebook.jp-mod-editMode'
+      });
     }
   }
 


### PR DESCRIPTION
Fixes: https://github.com/jupyterlab-contrib/jupyterlab-vim/issues/31

Many thanks to @fcollonval for suggesting the fix here: https://gitter.im/jupyterlab/jupyterlab?at=6120c9f2aa48d1340c2490d2

and to @kmdalton for reminding me to have a go at fixing this.