### PR TITLE
restore correct keybinding

### DIFF
--- a/History.md
+++ b/History.md
@@ -2,6 +2,9 @@
 
 ## Next
 
+## 0.15.1 / 2022-03-12
+  * Fixed a bug in `0.15.0` where you could no longer type `c`.
+
 ## 0.15.0 / 2022-03-11
 
   * Homogenize the project with the jupyterlab-contrib organization (#46)

--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -117,7 +117,7 @@
     },
     {
       "selector": ".jp-NotebookPanel[data-jp-vim-mode='true'] .jp-Notebook.jp-mod-editMode",
-      "keys": ["C"],
+      "keys": ["Accel 1"],
       "command": "notebook:change-cell-to-code"
     },
     {


### PR DESCRIPTION
Fixes: #63 

Left over from the adventures of getting #58 to work. It's worth doing a more complete check that nothing else was messed up along the way. But the inability to type `c` is pretty devastating so I'm going to merge this and make a new release.

Many thanks to @shinypond for prompt reporting!