### PR TITLE
Add "leave-current-mode" command to move insert->normal->command.

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,6 +1,7 @@
 # History
 
 ## Next
+  * Add bindable command to move insert-to-normal-to-command modes (#69)
 
 ## 0.15.1 / 2022-03-12
   * Fixed a bug in `0.15.0` where you could no longer type `c`.

--- a/src/labCommands.ts
+++ b/src/labCommands.ts
@@ -144,25 +144,28 @@ export function addJLabCommands(
       isEnabled
     }),
     commands.addCommand('vim:leave-current-mode', {
-        label: 'Move Insert to Normal to Jupyter Command Mode"',
-        execute: args => {
-            const current = getCurrent(args);
+      label: 'Move Insert to Normal to Jupyter Command Mode"',
+      execute: args => {
+        const current = getCurrent(args);
 
-            if (current) {
-                const { content } = current;
-                if (content.activeCell !== null) {
-                    let editor = content.activeCell.editor as CodeMirrorEditor;
+        if (current) {
+          const { content } = current;
+          if (content.activeCell !== null) {
+            const editor = content.activeCell.editor as CodeMirrorEditor;
 
-                    // Get the current editor state
-                    if (editor.editor.state.vim.insertMode || editor.editor.state.vim.visualMode) {
-                      (CodeMirror as any).Vim.handleKey(editor.editor, '<Esc>');
-                    } else {
-                      commands.execute('notebook:enter-command-mode');
-                    }
-                }
+            // Get the current editor state
+            if (
+              editor.editor.state.vim.insertMode ||
+              editor.editor.state.vim.visualMode
+            ) {
+              (CodeMirror as any).Vim.handleKey(editor.editor, '<Esc>');
+            } else {
+              commands.execute('notebook:enter-command-mode');
             }
-        },
-        isEnabled
+          }
+        }
+      },
+      isEnabled
     }),
     commands.addCommand('vim:select-below-execute-markdown', {
       label: 'Execute Markdown and Select Cell Below',

--- a/src/labCommands.ts
+++ b/src/labCommands.ts
@@ -143,6 +143,29 @@ export function addJLabCommands(
       },
       isEnabled
     }),
+    commands.addCommand('vim:leave-current-mode', {
+        label: 'Move Insert to Normal to Command Mode"',
+        execute: args => {
+            const current = getCurrent(args);
+
+            if (current) {
+                const { content } = current;
+                if (content.activeCell !== null) {
+                    let editor = content.activeCell.editor as CodeMirrorEditor;
+
+                    // Get the current editor state
+                    if(editor.editor.state.vim.insertMode) {
+                      (CodeMirror as any).Vim.handleKey(editor.editor, '<Esc>');
+                    } else if (editor.editor.state.vim.visualMode){
+                      (CodeMirror as any).Vim.handleKey(editor.editor, '<Esc>');
+                    } else {
+                      commands.execute('notebook:enter-command-mode');
+                    }
+                }
+            }
+        },
+        isEnabled
+    }),
     commands.addCommand('vim:select-below-execute-markdown', {
       label: 'Execute Markdown and Select Cell Below',
       execute: args => {

--- a/src/labCommands.ts
+++ b/src/labCommands.ts
@@ -144,7 +144,7 @@ export function addJLabCommands(
       isEnabled
     }),
     commands.addCommand('vim:leave-current-mode', {
-        label: 'Move Insert to Normal to Command Mode"',
+        label: 'Move Insert to Normal to Jupyter Command Mode"',
         execute: args => {
             const current = getCurrent(args);
 
@@ -154,9 +154,7 @@ export function addJLabCommands(
                     let editor = content.activeCell.editor as CodeMirrorEditor;
 
                     // Get the current editor state
-                    if(editor.editor.state.vim.insertMode) {
-                      (CodeMirror as any).Vim.handleKey(editor.editor, '<Esc>');
-                    } else if (editor.editor.state.vim.visualMode){
+                    if (editor.editor.state.vim.insertMode || editor.editor.state.vim.visualMode) {
                       (CodeMirror as any).Vim.handleKey(editor.editor, '<Esc>');
                     } else {
                       commands.execute('notebook:enter-command-mode');


### PR DESCRIPTION
As we know, jupyterlab is already a "modal" editor and (by default) has a "edit4" and "command" mode.
One switches between modes via Esc, a la vim. 

It's rather nice to preserve this behavior when adding the vim-modes so that Esc conceptually moves "up" a mode,
from vim-insert/lvisual to vim-normal and from vim-normal to jupyterlab-command.

Add a "Leave Current Mode" command, which can be rebound to Esc rather than "Leave Insert Mode".

This PR does *not* change the default Esc binding, which is separately proposed in #70.

Please finish the following when submitting a pull request:

- [x] Add a line to `History.md` briefly documenting the change.

If this is a release, additionally do the following:

- [x] Update the dependencies in `package.json`
- [x] Run `jlpm install` to update `yarn.lock`

Thanks!
