### PR TITLE
Rebind Esc to "Leave Current Mode"

### DIFF
--- a/History.md
+++ b/History.md
@@ -2,6 +2,7 @@
 
 ## Next
   * Add bindable command to move insert-to-normal-to-command modes (#69)
+  * Rebind Esc to leave-current-mode (#70)
 
 ## 0.15.1 / 2022-03-12
   * Fixed a bug in `0.15.0` where you could no longer type `c`.

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Shortcuts this extension introduces:
 | Command/Ctrl-2  | Markdown Cell Mode        |
 | Command/Ctrl-3  | Raw Cell Mode             |
 | Shift-Escape    | Leave Vim Mode            |
-| Escape, Ctrl-\[ | Exit Vim Insert Mode      |
+| Escape, Ctrl-\[ | Leave Insert or Vim Mode  |
 
 ### Jupyter command bindings
 

--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -83,12 +83,12 @@
     {
       "selector": ".jp-NotebookPanel[data-jp-vim-mode='true'] .jp-Notebook.jp-mod-editMode",
       "keys": ["Escape"],
-      "command": "vim:leave-insert-mode"
+      "command": "vim:leave-current-mode"
     },
     {
       "selector": ".jp-NotebookPanel[data-jp-vim-mode='true'] .jp-Notebook.jp-mod-editMode",
       "keys": ["Ctrl ["],
-      "command": "vim:leave-insert-mode"
+      "command": "vim:leave-current-mode"
     },
     {
       "selector": ".jp-NotebookPanel[data-jp-vim-mode='true'] .jp-Notebook:focus",


### PR DESCRIPTION
_This is an optional add-on to #69 that makes "Leave Current Mode" the default binding for Esc._

The leave-current-mode behavior of "Esc" could/should be made default for this plugin.
Though this is a shift in behavior for existing jupyterlab-vim users, it's less disruptive for existing jupyterlab users.

Please finish the following when submitting a pull request:

- [x] Add a line to `History.md` briefly documenting the change.

If this is a release, additionally do the following:

- [x] Update the dependencies in `package.json`
- [x] Run `jlpm install` to update `yarn.lock`

Thanks!
