### PR TITLE
Add configuration to provide custom keybindings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 18.x]
+        node-version: [14.x, 16.x]
 
     steps:
     - name: Checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x]
+        node-version: [14.x, 18.x]
 
     steps:
     - name: Checkout

--- a/modify-keybinds.md
+++ b/modify-keybinds.md
@@ -24,7 +24,8 @@ Jupyterlab commands don't know about the concept of vim modes so they will be ac
 `.jp-NotebookPanel[data-jp-vim-mode='true'] .jp-Notebook.jp-mod-editMode`
 
 
-**Vim remappings**
-For vim style remappings (`inoremap`, `imap`, `nmap`...) you can use the sibling extension [jupyterlab-vimrc](https://github.com/ianhi/jupyterlab-vimrc#jupyterlab-vimrc).  
+### Vim remappings
 
-Beware that this does not work with everything you may have in your standard vimrc. Jupyterlab uses [Codemirror] for the editors in cells. This extension adds vim support by enabling the [vim](https://codemirror.net/demo/vim.html) emulation in codemirror. While this comes with partial support for remappings in your vimrc the support is incomplete.
+Vim style remappings (`inoremap`, `imap`, `nmap`...) can be modified in the advanced settings editor under the `Notebook Vim` settings. Alternatively, you can use the sibling extension [jupyterlab-vimrc](https://github.com/ianhi/jupyterlab-vimrc#jupyterlab-vimrc) to do this.
+
+With either approach, Vim remappings do not work with everything you may have in your standard vimrc. Jupyterlab uses [Codemirror] for the editors in cells. This extension adds vim support by enabling the [vim](https://codemirror.net/demo/vim.html) emulation in codemirror. While this comes with partial support for remappings in your vimrc the support is incomplete. In particular, keybindings which use `noremap` don't work [unless the keybinding already exists in the default Codemirror Vim keybindings](https://github.com/codemirror/codemirror5/blob/b2d26b4ccb1d0994ae84d18ad8b84018de176da9/keymap/vim.js#L764-L766). If your keybinding doesn't work with `noremap`, try using `map`, and above all, avoid recursive remappings.

--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -2,261 +2,425 @@
   "title": "Notebook Vim",
   "description": "Notebook Vim Settings",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "jupyter.lab.shortcuts": [
     {
       "command": "notebook:enter-command-mode",
-      "keys": ["Escape"],
+      "keys": [
+        "Escape"
+      ],
       "selector": ".jp-Notebook.jp-mod-editMode",
       "disabled": true
     },
     {
       "selector": ".jp-NotebookPanel[data-jp-vim-mode='true'] .jp-Notebook.jp-mod-editMode",
-      "keys": ["Ctrl O", "U"],
+      "keys": [
+        "Ctrl O",
+        "U"
+      ],
       "command": "notebook:undo-cell-action"
     },
     {
       "selector": ".jp-NotebookPanel[data-jp-vim-mode='true'] .jp-NotebookPanel[data-jp-vim-mode='true'] .jp-Notebook.jp-mod-editMode",
-      "keys": ["Ctrl O", "-"],
+      "keys": [
+        "Ctrl O",
+        "-"
+      ],
       "command": "notebook:split-cell-at-cursor"
     },
     {
       "selector": ".jp-NotebookPanel[data-jp-vim-mode='true'] .jp-Notebook.jp-mod-editMode",
-      "keys": ["Ctrl O", "D"],
+      "keys": [
+        "Ctrl O",
+        "D"
+      ],
       "command": "vim:cut-cell-and-edit"
     },
     {
       "selector": ".jp-NotebookPanel[data-jp-vim-mode='true'] .jp-Notebook.jp-mod-editMode",
-      "keys": ["Ctrl O", "Y"],
+      "keys": [
+        "Ctrl O",
+        "Y"
+      ],
       "command": "vim:copy-cell-and-edit"
     },
     {
       "selector": ".jp-NotebookPanel[data-jp-vim-mode='true'] .jp-Notebook.jp-mod-editMode",
-      "keys": ["Ctrl O", "P"],
+      "keys": [
+        "Ctrl O",
+        "P"
+      ],
       "command": "vim:paste-cell-and-edit"
     },
     {
       "selector": ".jp-NotebookPanel[data-jp-vim-mode='true'] .jp-Notebook.jp-mod-editMode",
-      "keys": ["Ctrl Shift J"],
+      "keys": [
+        "Ctrl Shift J"
+      ],
       "command": "notebook:extend-marked-cells-below"
     },
     {
       "selector": ".jp-NotebookPanel[data-jp-vim-mode='true'] .jp-Notebook:focus",
-      "keys": ["Ctrl Shift J"],
+      "keys": [
+        "Ctrl Shift J"
+      ],
       "command": "notebook:extend-marked-cells-below"
     },
     {
       "selector": ".jp-NotebookPanel[data-jp-vim-mode='true'] .jp-Notebook.jp-mod-editMode",
-      "keys": ["Ctrl Shift K"],
+      "keys": [
+        "Ctrl Shift K"
+      ],
       "command": "notebook:extend-marked-cells-above"
     },
     {
       "selector": ".jp-NotebookPanel[data-jp-vim-mode='true'] .jp-Notebook:focus",
-      "keys": ["Ctrl Shift K"],
+      "keys": [
+        "Ctrl Shift K"
+      ],
       "command": "notebook:extend-marked-cells-above"
     },
     {
       "selector": ".jp-NotebookPanel[data-jp-vim-mode='true'] .jp-Notebook.jp-mod-editMode",
-      "keys": ["Ctrl O", "Shift O"],
+      "keys": [
+        "Ctrl O",
+        "Shift O"
+      ],
       "command": "notebook:insert-cell-above"
     },
     {
       "selector": ".jp-NotebookPanel[data-jp-vim-mode='true'] .jp-Notebook.jp-mod-editMode",
-      "keys": ["Ctrl O", "Ctrl O"],
+      "keys": [
+        "Ctrl O",
+        "Ctrl O"
+      ],
       "command": "notebook:insert-cell-above"
     },
     {
       "selector": ".jp-NotebookPanel[data-jp-vim-mode='true'] .jp-Notebook.jp-mod-editMode",
-      "keys": ["Ctrl O", "O"],
+      "keys": [
+        "Ctrl O",
+        "O"
+      ],
       "command": "notebook:insert-cell-below"
     },
     {
       "selector": ".jp-NotebookPanel[data-jp-vim-mode='true'] .jp-Notebook.jp-mod-editMode",
-      "keys": ["Ctrl J"],
+      "keys": [
+        "Ctrl J"
+      ],
       "command": "vim:select-below-execute-markdown"
     },
     {
       "selector": ".jp-NotebookPanel[data-jp-vim-mode='true'] .jp-Notebook.jp-mod-editMode",
-      "keys": ["Ctrl K"],
+      "keys": [
+        "Ctrl K"
+      ],
       "command": "vim:select-above-execute-markdown"
     },
     {
       "selector": ".jp-NotebookPanel[data-jp-vim-mode='true'] .jp-Notebook.jp-mod-editMode",
-      "keys": ["Escape"],
+      "keys": [
+        "Escape"
+      ],
       "command": "vim:leave-insert-mode"
     },
     {
       "selector": ".jp-NotebookPanel[data-jp-vim-mode='true'] .jp-Notebook.jp-mod-editMode",
-      "keys": ["Ctrl ["],
+      "keys": [
+        "Ctrl ["
+      ],
       "command": "vim:leave-insert-mode"
     },
     {
       "selector": ".jp-NotebookPanel[data-jp-vim-mode='true'] .jp-Notebook:focus",
-      "keys": ["Ctrl I"],
+      "keys": [
+        "Ctrl I"
+      ],
       "command": "vim:enter-insert-mode"
     },
     {
       "selector": ".jp-NotebookPanel[data-jp-vim-mode='true'] .jp-Notebook.jp-mod-editMode",
-      "keys": ["Ctrl Enter"],
+      "keys": [
+        "Ctrl Enter"
+      ],
       "command": "vim:run-cell-and-edit"
     },
     {
       "selector": ".jp-NotebookPanel[data-jp-vim-mode='true'] .jp-Notebook.jp-mod-editMode",
-      "keys": ["Shift Enter"],
+      "keys": [
+        "Shift Enter"
+      ],
       "command": "vim:run-select-next-edit"
     },
     {
       "selector": ".jp-NotebookPanel[data-jp-vim-mode='true'] .jp-Notebook.jp-mod-editMode",
-      "keys": ["Shift Escape"],
+      "keys": [
+        "Shift Escape"
+      ],
       "command": "notebook:enter-command-mode"
     },
     {
       "selector": ".jp-NotebookPanel[data-jp-vim-mode='true'] .jp-Notebook:focus",
-      "keys": ["Shift M"],
+      "keys": [
+        "Shift M"
+      ],
       "command": "vim:merge-and-edit"
     },
     {
       "selector": ".jp-NotebookPanel[data-jp-vim-mode='true'] .jp-Notebook.jp-mod-editMode",
-      "keys": ["Accel 1"],
+      "keys": [
+        "Accel 1"
+      ],
       "command": "notebook:change-cell-to-code"
     },
     {
       "selector": ".jp-NotebookPanel[data-jp-vim-mode='true'] .jp-Notebook.jp-mod-editMode",
-      "keys": ["Accel 2"],
+      "keys": [
+        "Accel 2"
+      ],
       "command": "notebook:change-cell-to-markdown"
     },
     {
       "selector": ".jp-NotebookPanel[data-jp-vim-mode='true'] .jp-Notebook.jp-mod-editMode",
-      "keys": ["Accel 3"],
+      "keys": [
+        "Accel 3"
+      ],
       "command": "notebook:change-cell-to-raw"
     },
     {
       "selector": ".jp-NotebookPanel[data-jp-vim-mode='true'] .jp-Notebook.jp-mod-editMode",
-      "keys": ["Ctrl O", "G"],
+      "keys": [
+        "Ctrl O",
+        "G"
+      ],
       "command": "vim:select-first-cell"
     },
     {
       "selector": ".jp-NotebookPanel[data-jp-vim-mode='true'] .jp-Notebook.jp-mod-editMode",
-      "keys": ["Ctrl O", "Ctrl G"],
+      "keys": [
+        "Ctrl O",
+        "Ctrl G"
+      ],
       "command": "vim:select-last-cell"
     },
     {
       "selector": ".jp-NotebookPanel[data-jp-vim-mode='true'] .jp-Notebook:focus",
-      "keys": ["G", "G"],
+      "keys": [
+        "G",
+        "G"
+      ],
       "command": "vim:select-first-cell"
     },
     {
       "selector": ".jp-NotebookPanel[data-jp-vim-mode='true'] .jp-Notebook:focus",
-      "keys": ["Shift G"],
+      "keys": [
+        "Shift G"
+      ],
       "command": "vim:select-last-cell"
     },
     {
       "selector": ".jp-NotebookPanel[data-jp-vim-mode='true'] .jp-Notebook:focus",
-      "keys": ["Y", "Y"],
+      "keys": [
+        "Y",
+        "Y"
+      ],
       "command": "notebook:copy-cell"
     },
     {
       "command": "notebook:cut-cell",
-      "keys": ["D", "D"],
+      "keys": [
+        "D",
+        "D"
+      ],
       "selector": ".jp-NotebookPanel[data-jp-vim-mode='true'] .jp-Notebook:focus"
     },
     {
       "selector": ".jp-NotebookPanel[data-jp-vim-mode='true'] .jp-Notebook:focus",
-      "keys": ["Shift P"],
+      "keys": [
+        "Shift P"
+      ],
       "command": "notebook:paste-cell-above"
     },
     {
       "selector": ".jp-NotebookPanel[data-jp-vim-mode='true'] .jp-Notebook:focus",
-      "keys": ["P"],
+      "keys": [
+        "P"
+      ],
       "command": "notebook:paste-cell-below"
     },
     {
       "selector": ".jp-NotebookPanel[data-jp-vim-mode='true'] .jp-Notebook:focus",
-      "keys": ["O"],
+      "keys": [
+        "O"
+      ],
       "command": "notebook:insert-cell-below"
     },
     {
       "selector": ".jp-NotebookPanel[data-jp-vim-mode='true'] .jp-Notebook:focus",
-      "keys": ["Shift O"],
+      "keys": [
+        "Shift O"
+      ],
       "command": "notebook:insert-cell-above"
     },
     {
       "selector": ".jp-NotebookPanel[data-jp-vim-mode='true'] .jp-Notebook:focus",
-      "keys": ["U"],
+      "keys": [
+        "U"
+      ],
       "command": "notebook:undo-cell-action"
     },
     {
       "selector": ".jp-NotebookPanel[data-jp-vim-mode='true'] .jp-Notebook:focus",
-      "keys": ["Ctrl E"],
+      "keys": [
+        "Ctrl E"
+      ],
       "command": "notebook:move-cell-down"
     },
     {
       "selector": ".jp-NotebookPanel[data-jp-vim-mode='true'] .jp-Notebook:focus",
-      "keys": ["Ctrl Y"],
+      "keys": [
+        "Ctrl Y"
+      ],
       "command": "notebook:move-cell-up"
     },
     {
       "selector": ".jp-NotebookPanel[data-jp-vim-mode='true'] .jp-Notebook:focus",
-      "keys": ["Z", "Z"],
+      "keys": [
+        "Z",
+        "Z"
+      ],
       "command": "vim:center-cell"
     },
     {
       "selector": ".jp-NotebookPanel[data-jp-vim-mode='true'] .jp-Notebook:focus",
-      "keys": ["Z", "C"],
+      "keys": [
+        "Z",
+        "C"
+      ],
       "command": "notebook:hide-cell-code"
     },
     {
       "selector": ".jp-NotebookPanel[data-jp-vim-mode='true'] .jp-Notebook:focus",
-      "keys": ["Z", "O"],
+      "keys": [
+        "Z",
+        "O"
+      ],
       "command": "notebook:show-cell-code"
     },
     {
       "selector": ".jp-NotebookPanel[data-jp-vim-mode='true'] .jp-Notebook:focus",
-      "keys": ["Z", "M"],
+      "keys": [
+        "Z",
+        "M"
+      ],
       "command": "notebook:hide-all-cell-code"
     },
     {
       "selector": ".jp-NotebookPanel[data-jp-vim-mode='true'] .jp-Notebook:focus",
-      "keys": ["Z", "R"],
+      "keys": [
+        "Z",
+        "R"
+      ],
       "command": "notebook:show-all-cell-code"
     },
     {
       "selector": ".jp-NotebookPanel[data-jp-vim-mode='true'] .jp-Notebook.jp-mod-editMode",
-      "keys": ["Ctrl O", "Z", "Z"],
+      "keys": [
+        "Ctrl O",
+        "Z",
+        "Z"
+      ],
       "command": "vim:center-cell"
     },
     {
       "selector": ".jp-NotebookPanel[data-jp-vim-mode='true'] .jp-Notebook.jp-mod-editMode .jp-InputArea-editor:not(.jp-mod-has-primary-selection)",
-      "keys": ["Ctrl G"],
+      "keys": [
+        "Ctrl G"
+      ],
       "command": "tooltip:launch-notebook"
     }
   ],
   "jupyter.lab.menus": {
-    "main":[
-    {
-      "id": "jp-mainmenu-settings",
-      "items": [
-        {
-          "type": "separator",
-          "rank": 38
-        },
-        {
-          "command": "jupyterlab-vim:toggle",
-          "rank": 38
-        },
-        {
-          "type": "separator",
-          "rank": 38
-        }
-      ]
-    }
-  ]},
+    "main": [
+      {
+        "id": "jp-mainmenu-settings",
+        "items": [
+          {
+            "type": "separator",
+            "rank": 38
+          },
+          {
+            "command": "jupyterlab-vim:toggle",
+            "rank": 38
+          },
+          {
+            "type": "separator",
+            "rank": 38
+          }
+        ]
+      }
+    ]
+  },
   "properties": {
     "enabled": {
       "type": "boolean",
       "title": "Enabled",
       "description": "Enable/disable notebook vim (may require a page refresh)",
       "default": true
+    },
+    "extraKeybindings": {
+      "type": "array",
+      "title": "Extra Vim Keybindings",
+      "items": {
+        "$ref": "#/definitions/shortcut"
+      },
+      "default": []
+    }
+  },
+  "definitions": {
+    "shortcut": {
+      "properties": {
+        "command": {
+          "title": "Keybinding",
+          "description": "The new vim keybinding, or 'left hand side' of the keybinding, e.g. `M`",
+          "type": "string"
+        },
+        "keys": {
+          "title": "The key sequence to execute",
+          "description": "The 'right hand side' of the keybinding to be executed, e.g. `:noh<cr>`",
+          "type": "string"
+        },
+        "context": {
+          "title": "Mode",
+          "description": "Vim mode in which the keybinding applies",
+          "enum": [
+            "normal",
+            "insert",
+            "visual"
+          ],
+          "default": "normal"
+        },
+        "mapfn": {
+          "title": "Map function",
+          "description": "Vim map function to use",
+          "enum": [
+            "map",
+            "noremap"
+          ],
+          "default": "map"
+        },
+        "enabled": {
+          "description": "Whether this keybinding is enabled or not.",
+          "type": "boolean",
+          "default": true
+        }
+      },
+      "required": [
+        "command",
+        "keys"
+      ],
+      "type": "object"
     }
   }
 }

--- a/src/codemirrorCommands.ts
+++ b/src/codemirrorCommands.ts
@@ -8,16 +8,28 @@ import { CommandRegistry } from '@lumino/commands';
  */
 const IS_MAC = !!navigator.platform.match(/Mac/i);
 
+export interface IKeybinding {
+  command: string;
+  keys: string;
+  context: string;
+  mapfn: string;
+  enabled: boolean;
+}
+
+export interface IOptions {
+  commands: CommandRegistry;
+  cm: CodeMirrorEditor;
+  enabled: boolean;
+  userKeybindings: IKeybinding[];
+}
+
 export class VimCellManager {
-  constructor(
-    commands: CommandRegistry,
-    cm: CodeMirrorEditor,
-    enabled: boolean
-  ) {
+  constructor({ commands, cm, enabled, userKeybindings }: IOptions) {
     this._commands = commands;
     this._cm = cm;
     this.enabled = enabled;
     this.lastActiveCell = null;
+    this.userKeybindings = userKeybindings ?? [];
   }
 
   onActiveCellChanged(
@@ -52,6 +64,34 @@ export class VimCellManager {
 
       const lcm = this._cm as any;
       const lvim = lcm.Vim as any;
+
+      // Clear existing user keybindings, then re-register in case they changed in the user settings
+      ['normal', 'visual', 'insert'].forEach(ctx => lvim.mapclear(ctx));
+      this.userKeybindings.forEach(
+        ({
+          command,
+          keys,
+          context,
+          mapfn,
+          enabled: keybindEnabled
+        }: IKeybinding) => {
+          console.debug({
+            command,
+            keys,
+            context,
+            mapfn,
+            enabled: keybindEnabled
+          });
+          if (keybindEnabled) {
+            if (mapfn === 'map') {
+              lvim.map(command, keys, context);
+            } else {
+              lvim.noremap(command, keys, context);
+            }
+          }
+        }
+      );
+
       lvim.defineEx('quit', 'q', (cm: any) => {
         this._commands.execute('notebook:enter-command-mode');
       });
@@ -197,4 +237,5 @@ export class VimCellManager {
   private _cm: CodeMirrorEditor;
   public lastActiveCell: Cell<ICellModel> | null;
   public enabled: boolean;
+  public userKeybindings: any;
 }

--- a/src/codemirrorCommands.ts
+++ b/src/codemirrorCommands.ts
@@ -75,13 +75,6 @@ export class VimCellManager {
           mapfn,
           enabled: keybindEnabled
         }: IKeybinding) => {
-          console.debug({
-            command,
-            keys,
-            context,
-            mapfn,
-            enabled: keybindEnabled
-          });
           if (keybindEnabled) {
             if (mapfn === 'map') {
               lvim.map(command, keys, context);
@@ -237,5 +230,5 @@ export class VimCellManager {
   private _cm: CodeMirrorEditor;
   public lastActiveCell: Cell<ICellModel> | null;
   public enabled: boolean;
-  public userKeybindings: any;
+  public userKeybindings: IKeybinding[];
 }


### PR DESCRIPTION
## Summary

This PR allows the user to configure custom Vim-mode keybindings using the advanced settings editor, closing #43.

@mlucool I tested binding `m` in normal mode to `:noh<CR>`, and that seems to work. CodeMirror cannot fully emulate Vim, and many keys will collide with browser or JupyterLab keybindings, so for example if you try to bind a command to `<Ctrl-/>` it will not work. In any case marks are not supported in CodeMirror so `m` in normal mode should work just fine.

## Changes

* Added the ability to create Vim keybindings in the advanced settings editor
* Set `additionalProperties` to `false` in `plugin.json` - it isn't being used here
* Refactored a bit of the logic inside `updateSettings` which deals with registering/unregistering commands, updating the tracker, and calling `modifyCell` to make it a bit simpler. This resolves a bug where the first call to `updateSettings` would succeed, but any subsequent call would not because it would try to re-register commands that were already registered.
* Updated the build matrix to remove node 12.x, and added node 18.x.
* My editor automatically runs JSON through `jq` (to automatically remove trailing `,` without me having to deal with it) which resulted in some reformatting of `plugin.json`. If this is a problem I can undo the reformatted lines.