### PR TITLE
BUG: Arrow keys navigation causes double cell hops

### DIFF
--- a/src/codemirrorCommands.ts
+++ b/src/codemirrorCommands.ts
@@ -170,7 +170,7 @@ export class VimCellManager {
               //    at the beginning of line for up move, and at the end for down move
               let cursor = cm.getCursor();
               let last_char = cm.doc.getLine(last).length;
-              if (cursor.ch !== last_char) {
+              if (cursor.line !== last || cursor.ch !== last_char) {
                 cm.setCursor({ line: last, ch: last_char })
                 this._commands.execute('notebook:move-cursor-down');
               }
@@ -185,7 +185,7 @@ export class VimCellManager {
               //    also arrow key navigation works properly when current cursor position 
               //    at the beginning of line for up move, and at the end for down move
               let cursor = cm.getCursor()
-              if (cursor.ch !== 0) {
+              if (cursor.line !== 0 || cursor.ch !== 0) {
                 cm.setCursor({ line: 0, ch: 0 })
                 this._commands.execute('notebook:move-cursor-up');
               }

--- a/src/codemirrorCommands.ts
+++ b/src/codemirrorCommands.ts
@@ -166,12 +166,12 @@ export class VimCellManager {
               this._commands.execute('notebook:move-cursor-down');
             } else {
               // This block preventing double cell hop when you use arrow keys for navigation
-              //    also arrow key navigation works properly when current cursor position 
+              //    also arrow key navigation works properly when current cursor position
               //    at the beginning of line for up move, and at the end for down move
-              let cursor = cm.getCursor();
+              const cursor = cm.getCursor();
               let last_char = cm.doc.getLine(last).length;
               if (cursor.line !== last || cursor.ch !== last_char) {
-                cm.setCursor({ line: last, ch: last_char })
+                cm.setCursor({ line: last, ch: last_char });
                 this._commands.execute('notebook:move-cursor-down');
               }
             }
@@ -182,11 +182,11 @@ export class VimCellManager {
               this._commands.execute('notebook:move-cursor-up');
             } else {
               // This block preventing double cell hop when you use arrow keys for navigation
-              //    also arrow key navigation works properly when current cursor position 
+              //    also arrow key navigation works properly when current cursor position
               //    at the beginning of line for up move, and at the end for down move
-              let cursor = cm.getCursor()
+              const cursor = cm.getCursor();
               if (cursor.line !== 0 || cursor.ch !== 0) {
-                cm.setCursor({ line: 0, ch: 0 })
+                cm.setCursor({ line: 0, ch: 0 });
                 this._commands.execute('notebook:move-cursor-up');
               }
             }

--- a/src/codemirrorCommands.ts
+++ b/src/codemirrorCommands.ts
@@ -169,7 +169,7 @@ export class VimCellManager {
               //    also arrow key navigation works properly when current cursor position
               //    at the beginning of line for up move, and at the end for down move
               const cursor = cm.getCursor();
-              let last_char = cm.doc.getLine(last).length;
+              const last_char = cm.doc.getLine(last).length;
               if (cursor.line !== last || cursor.ch !== last_char) {
                 cm.setCursor({ line: last, ch: last_char });
                 this._commands.execute('notebook:move-cursor-down');


### PR DESCRIPTION
Arrow navigation was handled improperly, in vim normal mode pressing UpArrow/DnArrow lead to double cell hops.

How to reproduce:
Add some arbitrary cells (multiline, single line, markdowns) and try to navigate with arrows instead of J/K. Sometimes you'll get double cell hop

I manually tested the following cases:
1. Multiline code cell
2. Empty /single line code cell
3. Move up from the middle of the top line
4. Move down from the middle of the last line
5. Move up from first char of the code cell
6. Move down from the last char of the code cell
7. Repeated action from the middle of the cell (i.e. 6<Up> , 7<Dn> combination)
8. Markdown handling worked weird, probably because arrow keys change the active cell value before it got to the Vim handler. So I decided to keep markdown cell as code until explicit Shift+Ctrl. This is close to original Jupyter behavior and probably should be fine.