### PR TITLE
Clear input state if applicable before hopping out of normal mode to jupyter command mode

### DIFF
--- a/src/labCommands.ts
+++ b/src/labCommands.ts
@@ -175,7 +175,13 @@ export function addNotebookCommands(
             const vim = cm.state.vim;
 
             // Get the current editor state
-            if (vim.insertMode || vim.visualMode) {
+            if (
+              vim.insertMode ||
+              vim.visualMode ||
+              vim.inputState.operator !== null ||
+              vim.inputState.motion !== null ||
+              vim.inputState.keyBuffer.length !== 0
+            ) {
               Vim.handleKey(cm, '<Esc>');
             } else {
               commands.execute('notebook:enter-command-mode');


### PR DESCRIPTION
For example if I press `d` then `<Esc>` in normal mode (i.e. about to delete something but changed my mind), I expect to be still in normal mode instead of jupyter command mode.