### PR TITLE
build: don't require package.json for python import

### DIFF
--- a/jupyterlab_vim/__init__.py
+++ b/jupyterlab_vim/__init__.py
@@ -12,6 +12,6 @@ with (HERE / "labextension" / "package.json").open() as fid:
 def _jupyter_labextension_paths():
     return [{
         "src": "labextension",
-        "dest": data["name"]
+        "name": "@axlair/jupyterlab_vim",
     }]
 


### PR DESCRIPTION
Following: https://github.com/jupyterlab/extension-template/blob/6356b296facbd4f9283493a5eab16e24e236407a/template/%7B%7Bpython_name%7D%7D/__init__.py.jinja#L13-L16

I think this is necessary to fix the issues we're having with the conda build