### PR TITLE
Fix for attempting to update editor when there was none

### DIFF
--- a/src/codemirrorCommands.ts
+++ b/src/codemirrorCommands.ts
@@ -61,6 +61,9 @@ export class VimEditorManager {
   }
 
   updateLastActive() {
+    if (!this._lastActiveEditor) {
+      return;
+    }
     this.modifyEditor(this._lastActiveEditor);
   }
 
@@ -161,6 +164,9 @@ export class VimCellManager extends VimEditorManager {
   }
 
   updateLastActive() {
+    if (!this._lastActiveCell) {
+      return;
+    }
     this.modifyCell(this._lastActiveCell);
   }
 


### PR DESCRIPTION
Closes #94

This lead to an uncaught exception breaking application of vim dataset flag on notebooks, and thus breaking the Escape and commands in notebooks opened afterwards.