### PR TITLE
Fix noremap key bindings

### DIFF
--- a/src/codemirrorCommands.ts
+++ b/src/codemirrorCommands.ts
@@ -129,7 +129,7 @@ export class VimEditorManager {
             if (mapfn === 'map') {
               Vim.map(command, keys, context);
             } else {
-              Vim.noremap(command, keys, context);
+              Vim.map(command, keys, context, true);
             }
           }
         }


### PR DESCRIPTION
Updates `noremap` based on changes in https://github.com/replit/codemirror-vim/pull/114 to fix `noremap` key bindings