### PR TITLE
Fix `modifyCell` or `modifyEditor` not called after text editor is opened after notebook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 - fix: override browser shift-esc in command mode [#100](https://github.com/jupyterlab-contrib/jupyterlab-vim/pull/100) ([@ianhi](https://github.com/ianhi))
   - Additional thanks to [@petergthatsme](https://github.com/petergthatsme) [@firai](https://github.com/firai) [@lukashergt](https://github.com/lukashergt) for reporting, debugging and testing
-- Fix __init__.py for wheel [#99](https://github.com/jupyterlab-contrib/jupyterlab-vim/pull/99) ([@fcollonval](https://github.com/fcollonval))
+- Fix `__init__.py` for wheel [#99](https://github.com/jupyterlab-contrib/jupyterlab-vim/pull/99) ([@fcollonval](https://github.com/fcollonval))
 
 ### Maintenance and upkeep improvements
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -147,18 +147,16 @@ async function activateCellVim(
   );
   let shell = app.shell as ILabShell;
   shell.currentChanged.connect(() => {
-      const current = shell.currentWidget;
-      if (!current) {
-        // no-op
-      } else if (editorTracker.currentWidget === current) {
-        editorManager.modifyEditor(editorTracker.currentWidget.content.editor);
-      } else if (notebookTracker.currentWidget === current) {
-        cellManager.modifyCell(
-          notebookTracker.currentWidget.content.activeCell
-        );
-      } else {
-        // no-op
-      }
+    const current = shell.currentWidget;
+    if (!current) {
+      // no-op
+    } else if (editorTracker.currentWidget === current) {
+      editorManager.modifyEditor(editorTracker.currentWidget.content.editor);
+    } else if (notebookTracker.currentWidget === current) {
+      cellManager.modifyCell(notebookTracker.currentWidget.content.activeCell);
+    } else {
+      // no-op
+    }
   });
 
   addNotebookCommands(app, notebookTracker);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import {
+  ILabShell,
   JupyterFrontEnd,
   JupyterFrontEndPlugin
 } from '@jupyterlab/application';
@@ -140,8 +141,13 @@ async function activateCellVim(
     cellManager.onActiveCellChanged,
     cellManager
   );
-  notebookTracker.currentChanged.connect(() => {
-      const current = app.shell.currentWidget;
+  editorTracker.currentChanged.connect(
+    editorManager.onActiveEditorChanged,
+    editorManager
+  );
+  let shell = app.shell as ILabShell;
+  shell.currentChanged.connect(() => {
+      const current = shell.currentWidget;
       if (!current) {
         console.warn('Current widget not found');
       } else if (editorTracker.currentWidget === current) {
@@ -154,10 +160,6 @@ async function activateCellVim(
         console.warn('Current widget is not vim-enabled');
       }
   });
-  editorTracker.currentChanged.connect(
-    editorManager.onActiveEditorChanged,
-    editorManager
-  );
 
   addNotebookCommands(app, notebookTracker);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -142,10 +142,14 @@ async function activateCellVim(
   );
   notebookTracker.currentChanged.connect(() => {
       const current = app.shell.currentWidget;
-      if (notebookTracker.currentWidget === current) {
+      if (!current) {
+        console.warn('Current widget not found');
+      } else if (notebookTracker.currentWidget === current) {
         cellManager.modifyCell(
           notebookTracker.currentWidget.content.activeCell
         );
+      } else {
+        console.warn('Current widget is not vim-enabled');
       }
   });
   editorTracker.currentChanged.connect(

--- a/src/index.ts
+++ b/src/index.ts
@@ -141,8 +141,8 @@ async function activateCellVim(
     cellManager
   );
   notebookTracker.currentChanged.connect(
-    editorManager.onActiveEditorChanged,
-    editorManager
+    cellManager.onActiveCellChanged,
+    cellManager
   );
   editorTracker.currentChanged.connect(
     editorManager.onActiveEditorChanged,

--- a/src/index.ts
+++ b/src/index.ts
@@ -149,7 +149,7 @@ async function activateCellVim(
   shell.currentChanged.connect(() => {
       const current = shell.currentWidget;
       if (!current) {
-        console.warn('Current widget not found');
+        // no-op
       } else if (editorTracker.currentWidget === current) {
         editorManager.modifyEditor(editorTracker.currentWidget.content.editor);
       } else if (notebookTracker.currentWidget === current) {
@@ -157,7 +157,7 @@ async function activateCellVim(
           notebookTracker.currentWidget.content.activeCell
         );
       } else {
-        console.warn('Current widget is not vim-enabled');
+        // no-op
       }
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -140,10 +140,14 @@ async function activateCellVim(
     cellManager.onActiveCellChanged,
     cellManager
   );
-  notebookTracker.currentChanged.connect(
-    cellManager.onActiveCellChanged,
-    cellManager
-  );
+  notebookTracker.currentChanged.connect(() => {
+      const current = app.shell.currentWidget;
+      if (notebookTracker.currentWidget === current) {
+        cellManager.modifyCell(
+          notebookTracker.currentWidget.content.activeCell
+        );
+      }
+  });
   editorTracker.currentChanged.connect(
     editorManager.onActiveEditorChanged,
     editorManager

--- a/src/index.ts
+++ b/src/index.ts
@@ -144,6 +144,8 @@ async function activateCellVim(
       const current = app.shell.currentWidget;
       if (!current) {
         console.warn('Current widget not found');
+      } else if (editorTracker.currentWidget === current) {
+        editorManager.modifyEditor(editorTracker.currentWidget.content.editor);
       } else if (notebookTracker.currentWidget === current) {
         cellManager.modifyCell(
           notebookTracker.currentWidget.content.activeCell

--- a/src/index.ts
+++ b/src/index.ts
@@ -140,6 +140,10 @@ async function activateCellVim(
     cellManager.onActiveCellChanged,
     cellManager
   );
+  notebookTracker.currentChanged.connect(
+    editorManager.onActiveEditorChanged,
+    editorManager
+  );
   editorTracker.currentChanged.connect(
     editorManager.onActiveEditorChanged,
     editorManager

--- a/src/index.ts
+++ b/src/index.ts
@@ -145,7 +145,7 @@ async function activateCellVim(
     editorManager.onActiveEditorChanged,
     editorManager
   );
-  let shell = app.shell as ILabShell;
+  const shell = app.shell as ILabShell;
   shell.currentChanged.connect(() => {
     const current = shell.currentWidget;
     if (!current) {


### PR DESCRIPTION
Fixes #103.

On `ILabShell` `currentChanged()`, check if `currentWidget` matches one tracked by `editorTracker` or `notebookTracker`, and call `modifyEditor()` or `modifyCell()` accordingly.

@krassowski, can you please help review whether this is right approach?