### PR TITLE
Fix search box `Esc` bindings

### DIFF
--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -16,6 +16,16 @@
       "selector": ".jp-FileEditor"
     },
     {
+      "command": "documentsearch:end",
+      "keys": ["Escape"],
+      "selector": ".jp-mod-searchable .jp-FileEditor [data-jp-vim-mode-name='normal']"
+    },
+    {
+      "command": "documentsearch:end",
+      "keys": ["Escape"],
+      "selector": ".jp-mod-search-active .jp-FileEditor [data-jp-vim-mode-name='normal']"
+    },
+    {
       "selector": ".jp-NotebookPanel[data-jp-vim-mode='true'] .jp-Notebook.jp-mod-editMode",
       "keys": ["Ctrl O", "U"],
       "command": "notebook:undo-cell-action"

--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -16,26 +16,6 @@
       "selector": ".jp-FileEditor"
     },
     {
-      "command": "documentsearch:end",
-      "keys": ["Escape"],
-      "selector": ".jp-mod-searchable .jp-FileEditor .cm-vimMode"
-    },
-    {
-      "command": "documentsearch:end",
-      "keys": ["Escape"],
-      "selector": ".jp-mod-searchable .jp-Notebook .cm-vimMode"
-    },
-    {
-      "command": "documentsearch:end",
-      "keys": ["Escape"],
-      "selector": ".jp-mod-search-active .jp-FileEditor .cm-vimMode"
-    },
-    {
-      "command": "documentsearch:end",
-      "keys": ["Escape"],
-      "selector": ".jp-mod-search-active .jp-Notebook .cm-vimMode"
-    },
-    {
       "selector": ".jp-NotebookPanel[data-jp-vim-mode='true'] .jp-Notebook.jp-mod-editMode",
       "keys": ["Ctrl O", "U"],
       "command": "notebook:undo-cell-action"

--- a/src/codemirrorCommands.ts
+++ b/src/codemirrorCommands.ts
@@ -67,13 +67,17 @@ export class VimEditorManager {
     this.modifyEditor(this._lastActiveEditor);
   }
 
+  /**
+   * Hook up vim mode into given editor.
+   * Returns true if vim mode was enabled.
+   */
   modifyEditor(editor: CodeEditor.IEditor | null): boolean {
-    // JupyterLab 4.0 only supports CodeMirror editors
-    const mirrorEditor = editor as CodeMirrorEditor | null;
-
-    if (!mirrorEditor) {
+    if (!editor) {
       throw Error('Editor not available');
     }
+    // JupyterLab 4.0 only supports CodeMirror editors
+    const mirrorEditor = editor as CodeMirrorEditor;
+
     this._lastActiveEditor = mirrorEditor;
 
     const view = mirrorEditor.editor;
@@ -89,6 +93,9 @@ export class VimEditorManager {
         // as blurred because it exists outside of the CodeMirror6 state; here
         // we override `hasFocus` handler to ensure it is taken into account.
         const cm = getCM(view)!;
+        cm.on('vim-mode-change', () => {
+          editor.host.dataset.jpVimModeName = cm.state.vim.mode;
+        });
         mirrorEditor.hasFocus = () => {
           if (
             cm.state.dialog &&


### PR DESCRIPTION
Fixes #104. PR courtesy of @krassowski. 

- Delete <kbd>Esc</kbd> → `documentsearch:end` bindings for notebooks. 
- Add `data-jp-vim-mode-name=mode` class to CodeMirror instances, where `mode` can be`"normal"`, `"insert"`, `"visual"` or `"visual block"`. 
- Change file editor <kbd>Esc</kbd> → `documentsearch:end` bindings' `.cm-vimMode` selectors to `[data-jp-vim-mode-name='normal']`. 