### PR TITLE
Add settings to enable double duty `Esc` and to disable `Shift-Esc` override in Command mode

### DIFF
--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -285,19 +285,18 @@
       "description": "Enable/disable vim in text editors (may require a page refresh)",
       "default": true
     },
-    "enterCmdModeKey": {
+    "cmdModeKeys": {
       "type": "object",
-      "title": "Shortcut Key for Entering Jupyter Command Mode in Notebooks",
-      "description": "Shortcut key for switching from vim Normal mode to Jupyter Command mode in notebooks. A custom shortcut key may be set by assigning the key to notebook - Enter Command Mode (`notebook:enter-command-mode`) in the Keyboard Shortcuts settings editor.",
+      "title": "Notebook Shortcut Key Bindings for Switching from vim Normal mode to Jupyter Command mode",
       "properties": {
-        "escEnterCmdMode": {
+        "escToCmdMode": {
           "type": "boolean",
-          "title": "Esc",
+          "title": "`Esc` leaves vim Normal mode to Jupyter Command mode",
           "default": true
         },
-        "shiftEscEnterCmdMode": {
+        "shiftEscOverrideBrowser": {
           "type": "boolean",
-          "title": "Shift-Esc",
+          "title": "Shift-Esc overrides browser shortcut in Jupyter Command mode",
           "default": true
         }
       }

--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -297,7 +297,7 @@
     },
     "cmdModeKeys": {
       "type": "object",
-      "title": "Notebook Shortcut Key Bindings for Switching from vim Normal mode to Jupyter Command mode",
+      "title": "Notebook shortcut key bindings for switching from vim Normal mode to Jupyter Command mode",
       "properties": {
         "escToCmdMode": {
           "type": "boolean",

--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -285,6 +285,23 @@
       "description": "Enable/disable vim in text editors (may require a page refresh)",
       "default": true
     },
+    "enterCmdModeKey": {
+      "type": "object",
+      "title": "Shortcut Key for Entering Jupyter Command Mode in Notebooks",
+      "description": "Shortcut key for switching from vim Normal mode to Jupyter Command mode in notebooks. A custom shortcut key may be set by assigning the key to notebook - Enter Command Mode (`notebook:enter-command-mode`) in the Keyboard Shortcuts settings editor.",
+      "properties": {
+        "escEnterCmdMode": {
+          "type": "boolean",
+          "title": "Esc",
+          "default": true
+        },
+        "shiftEscEnterCmdMode": {
+          "type": "boolean",
+          "title": "Shift-Esc",
+          "default": true
+        }
+      }
+    },
     "extraKeybindings": {
       "type": "array",
       "title": "Extra Vim Keybindings",

--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -96,14 +96,24 @@
       "command": "vim:select-above-execute-markdown"
     },
     {
-      "selector": ".jp-NotebookPanel[data-jp-vim-mode='true'] .jp-Notebook.jp-mod-editMode",
+      "selector": ".jp-NotebookPanel[data-jp-vim-mode='true'][data-jp-vim-esc-to-cmd-mode='false'] .jp-Notebook.jp-mod-editMode",
       "keys": ["Escape"],
       "command": "vim:leave-insert-mode"
     },
     {
-      "selector": ".jp-NotebookPanel[data-jp-vim-mode='true'] .jp-Notebook.jp-mod-editMode",
+      "selector": ".jp-NotebookPanel[data-jp-vim-mode='true'][data-jp-vim-esc-to-cmd-mode='true'] .jp-Notebook.jp-mod-editMode",
+      "keys": ["Escape"],
+      "command": "vim:leave-current-mode"
+    },
+    {
+      "selector": ".jp-NotebookPanel[data-jp-vim-mode='true'][data-jp-vim-esc-to-cmd-mode='false'] .jp-Notebook.jp-mod-editMode",
       "keys": ["Ctrl ["],
       "command": "vim:leave-insert-mode"
+    },
+    {
+      "selector": ".jp-NotebookPanel[data-jp-vim-mode='true'][data-jp-vim-esc-to-cmd-mode='true'] .jp-Notebook.jp-mod-editMode",
+      "keys": ["Ctrl ["],
+      "command": "vim:leave-current-mode"
     },
     {
       "selector": ".jp-NotebookPanel[data-jp-vim-mode='true'] .jp-Notebook:focus",
@@ -126,7 +136,7 @@
       "command": "notebook:enter-command-mode"
     },
     {
-      "selector": ".jp-Notebook.jp-mod-commandMode",
+      "selector": ".jp-NotebookPanel[data-jp-vim-mode='true'][data-jp-vim-shift-esc-override-browser='true'] .jp-Notebook.jp-mod-commandMode",
       "keys": ["Shift Escape"],
       "command": ""
     },
@@ -291,12 +301,12 @@
       "properties": {
         "escToCmdMode": {
           "type": "boolean",
-          "title": "`Esc` leaves vim Normal mode to Jupyter Command mode",
+          "title": "Enable `Esc` and `Ctrl-[` leaving vim Normal mode to Jupyter Command mode",
           "default": true
         },
         "shiftEscOverrideBrowser": {
           "type": "boolean",
-          "title": "Shift-Esc overrides browser shortcut in Jupyter Command mode",
+          "title": "Override `Shift-Esc` browser shortcut in Jupyter Command mode",
           "default": true
         }
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -179,11 +179,8 @@ async function activateCellVim(
     if (!enterCmdModeKey) {
       // no-op
     } else {
-      console.log(enterCmdModeKey);
       escEnterCmdMode = enterCmdModeKey['escEnterCmdMode'] as boolean;
-      console.log(escEnterCmdMode);
       shiftEscEnterCmdMode = enterCmdModeKey['shiftEscEnterCmdMode'] as boolean;
-      console.log(shiftEscEnterCmdMode);
     }
 
     app.commands.notifyCommandChanged(TOGGLE_ID);

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,11 +23,14 @@ import {
   IKeybinding
 } from './codemirrorCommands';
 import { addNotebookCommands } from './labCommands';
+import { PartialJSONObject } from '@lumino/coreutils';
 
 const PLUGIN_NAME = '@axlair/jupyterlab_vim';
 const TOGGLE_ID = 'jupyterlab-vim:toggle';
 let enabled = false;
 let enabledInEditors = true;
+let escEnterCmdMode = true;
+let shiftEscEnterCmdMode = true;
 
 /**
  * Initialization data for the jupyterlab_vim extension.
@@ -170,6 +173,19 @@ async function activateCellVim(
 
     enabled = settings.get('enabled').composite === true;
     enabledInEditors = settings.get('enabledInEditors').composite === true;
+
+    const enterCmdModeKey = settings.get('enterCmdModeKey')
+      .composite as PartialJSONObject;
+    if (!enterCmdModeKey) {
+      // no-op
+    } else {
+      console.log(enterCmdModeKey);
+      escEnterCmdMode = enterCmdModeKey['escEnterCmdMode'] as boolean;
+      console.log(escEnterCmdMode);
+      shiftEscEnterCmdMode = enterCmdModeKey['shiftEscEnterCmdMode'] as boolean;
+      console.log(shiftEscEnterCmdMode);
+    }
+
     app.commands.notifyCommandChanged(TOGGLE_ID);
 
     cellManager.enabled = enabled;
@@ -194,6 +210,8 @@ async function activateCellVim(
 
     notebookTracker.forEach(notebook => {
       notebook.node.dataset.jpVimMode = `${enabled}`;
+      notebook.node.dataset.jpVimEscEnterCmdMode = `${escEnterCmdMode}`;
+      notebook.node.dataset.jpVimShiftEscEnterCmdMode = `${shiftEscEnterCmdMode}`;
     });
     editorTracker.forEach(document => {
       document.node.dataset.jpVimMode = `${enabled && enabledInEditors}`;
@@ -204,6 +222,8 @@ async function activateCellVim(
     // make sure our css selector is added to new notebooks
     notebookTracker.widgetAdded.connect((sender, notebook) => {
       notebook.node.dataset.jpVimMode = `${enabled}`;
+      notebook.node.dataset.jpVimEscEnterCmdMode = `${escEnterCmdMode}`;
+      notebook.node.dataset.jpVimShiftEscEnterCmdMode = `${shiftEscEnterCmdMode}`;
     });
     editorTracker.widgetAdded.connect((sender, document) => {
       document.node.dataset.jpVimMode = `${enabled && enabledInEditors}`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,8 +29,8 @@ const PLUGIN_NAME = '@axlair/jupyterlab_vim';
 const TOGGLE_ID = 'jupyterlab-vim:toggle';
 let enabled = false;
 let enabledInEditors = true;
-let escEnterCmdMode = true;
-let shiftEscEnterCmdMode = true;
+let escToCmdMode = true;
+let shiftEscOverrideBrowser = true;
 
 /**
  * Initialization data for the jupyterlab_vim extension.
@@ -174,13 +174,15 @@ async function activateCellVim(
     enabled = settings.get('enabled').composite === true;
     enabledInEditors = settings.get('enabledInEditors').composite === true;
 
-    const enterCmdModeKey = settings.get('enterCmdModeKey')
+    const cmdModeKeys = settings.get('cmdModeKeys')
       .composite as PartialJSONObject;
-    if (!enterCmdModeKey) {
+    if (!cmdModeKeys) {
       // no-op
     } else {
-      escEnterCmdMode = enterCmdModeKey['escEnterCmdMode'] as boolean;
-      shiftEscEnterCmdMode = enterCmdModeKey['shiftEscEnterCmdMode'] as boolean;
+      escToCmdMode = cmdModeKeys['escToCmdMode'] as boolean;
+      shiftEscOverrideBrowser = cmdModeKeys[
+        'shiftEscOverrideBrowser'
+      ] as boolean;
     }
 
     app.commands.notifyCommandChanged(TOGGLE_ID);
@@ -207,8 +209,8 @@ async function activateCellVim(
 
     notebookTracker.forEach(notebook => {
       notebook.node.dataset.jpVimMode = `${enabled}`;
-      notebook.node.dataset.jpVimEscEnterCmdMode = `${escEnterCmdMode}`;
-      notebook.node.dataset.jpVimShiftEscEnterCmdMode = `${shiftEscEnterCmdMode}`;
+      notebook.node.dataset.jpVimEscToCmdMode = `${escToCmdMode}`;
+      notebook.node.dataset.jpVimShiftEscOverrideBrowser = `${shiftEscOverrideBrowser}`;
     });
     editorTracker.forEach(document => {
       document.node.dataset.jpVimMode = `${enabled && enabledInEditors}`;
@@ -219,8 +221,8 @@ async function activateCellVim(
     // make sure our css selector is added to new notebooks
     notebookTracker.widgetAdded.connect((sender, notebook) => {
       notebook.node.dataset.jpVimMode = `${enabled}`;
-      notebook.node.dataset.jpVimEscEnterCmdMode = `${escEnterCmdMode}`;
-      notebook.node.dataset.jpVimShiftEscEnterCmdMode = `${shiftEscEnterCmdMode}`;
+      notebook.node.dataset.jpVimEscToCmdMode = `${escToCmdMode}`;
+      notebook.node.dataset.jpVimShiftEscOverrideBrowser = `${shiftEscOverrideBrowser}`;
     });
     editorTracker.widgetAdded.connect((sender, document) => {
       document.node.dataset.jpVimMode = `${enabled && enabledInEditors}`;


### PR DESCRIPTION
- Add setting to close #101. When this option is enabled, pressing <kbd>Esc</kbd> in secession moves from vim Insert/Visual modes → vim Normal mode → Jupyter Command mode. As with vim, <kbd>Esc</kbd> and <kbd>Ctrl-[</kbd> are treated as being synonymous, so they're controlled by the same setting. I am proposing to enabling this by default, since I don't see any downsides.
- Add setting to optionally disable #100. 
- Fix #111. 

![image](https://github.com/jupyterlab-contrib/jupyterlab-vim/assets/23555/a1bbf1d2-bd14-46cc-ad04-155fdbc4545a)

Comments are welcome.
