### PR TITLE
Change `Ctrl + Enter` to render Markdown cells

### DIFF
--- a/src/labCommands.ts
+++ b/src/labCommands.ts
@@ -58,13 +58,14 @@ export function addNotebookCommands(
 
         if (current) {
           const { context, content } = current;
+          NotebookActions.run(content, context.sessionContext);
+          // Don't re-enter edit mode for markdown cells
           if (
             content.activeCell !== null &&
             content.activeCell.model.type === 'markdown'
           ) {
-            commands.execute('notebook:run-cell');
+            // no-op
           } else {
-            NotebookActions.run(content, context.sessionContext);
             current.content.mode = 'edit';
           }
         }

--- a/src/labCommands.ts
+++ b/src/labCommands.ts
@@ -58,8 +58,15 @@ export function addNotebookCommands(
 
         if (current) {
           const { context, content } = current;
-          NotebookActions.run(content, context.sessionContext);
-          current.content.mode = 'edit';
+          if (
+            content.activeCell !== null &&
+            content.activeCell.model.type === 'markdown'
+          ) {
+            commands.execute('notebook:run-cell');
+          } else {
+            NotebookActions.run(content, context.sessionContext);
+            current.content.mode = 'edit';
+          }
         }
       },
       isEnabled


### PR DESCRIPTION
## References

Closes #120 

## Code changes

Don't re-enter edit mode for Markdown cells in `vim:run-cell-and-edit`.

## Additional context

This command has been contradictory for Markdown cells, as JL exits edit mode when rendering Markdown by design. This command previously prioritized staying in edit mode, which effectively resulted in no actions being taken for Markdown cells when the command is called.

Since the user pressed a key binding to call the command and therefore presumably expected something to happen, I think this proposed change to prioritize rendering the cell for Markdown cells is acceptable.