### PR TITLE
Fix empty command

### DIFF
--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -138,7 +138,7 @@
     {
       "selector": ".jp-NotebookPanel[data-jp-vim-mode='true'][data-jp-vim-shift-esc-override-browser='true'] .jp-Notebook.jp-mod-commandMode",
       "keys": ["Shift Escape"],
-      "command": ""
+      "command": "vim:no-action"
     },
     {
       "selector": ".jp-NotebookPanel[data-jp-vim-mode='true'] .jp-Notebook:focus",

--- a/src/labCommands.ts
+++ b/src/labCommands.ts
@@ -166,7 +166,7 @@ export function addNotebookCommands(
       isEnabled
     }),
     commands.addCommand('vim:leave-current-mode', {
-      label: 'Move Insert to Normal to Jupyter Command Mode"',
+      label: 'Move Insert to Normal to Jupyter Command Mode',
       execute: args => {
         const current = getCurrent(args);
 

--- a/src/labCommands.ts
+++ b/src/labCommands.ts
@@ -284,6 +284,14 @@ export function addNotebookCommands(
         }
       },
       isEnabled
+    }),
+    commands.addCommand('vim:no-action', {
+      label: 'Prevent Default Browser Action',
+      caption:
+        'Prevent default action for some keybindings (defined in the settings); for example Firefox binds Shift + Esc to its Process Manager which conflicts with the expected action in the vim mode.',
+      execute: args => {
+        // no-op
+      }
     })
   ];
   return addedCommands;


### PR DESCRIPTION
The PR https://github.com/jupyterlab-contrib/jupyterlab-vim/pull/100 which fixed #73 broke the filtering in JupyterLab shortcuts UI (https://github.com/jupyterlab/jupyterlab/issues/15687). While this was addressed in JupyterLab (https://github.com/jupyterlab/jupyterlab/pull/15695), the shortcut added by `vim` extension is currently not labelled as such and shows up at the top of the list:

![image](https://github.com/jupyterlab-contrib/jupyterlab-vim/assets/5832902/d967c818-3e71-4430-8508-82adbfe4b740)

This PR adds a dummy command for this action, so that it is better documented for the user and in the code, also fixing the problem with missing category (and for users of an older JupyterLab version):

![image](https://github.com/jupyterlab-contrib/jupyterlab-vim/assets/5832902/4e9409b5-f190-487f-b2ff-9e1fb3ec4790)

Also fixes a typo in another command name.