### PR TITLE
Readme cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Shortcuts that this extension introduces:
 | Command/Ctrl-2 | Markdown Cell Mode        |
 | Command/Ctrl-3 | Raw Cell Mode             |
 | Shift-Esc      | Exit to Command Mode      |
-| Esc or Ctrl-\[ | Exit Current Mode        |
+| Esc or Ctrl-\[ | Exit Current Mode         |
 
 ### Jupyter command bindings
 

--- a/README.md
+++ b/README.md
@@ -60,22 +60,22 @@ Shortcuts that this extension introduces:
 
 | Chord          | Action                    |
 | -------------- | ------------------------- |
-| Ctrl-O, U      | Undo Cell Action          |
 | -              | Split Cell at Cursor      |
 | Ctrl-O, -      | Split Cell at Cursor      |
-| Ctrl-O, D      | Cut Cell                  |
-| Ctrl-O, Y      | Copy Cell                 |
-| Ctrl-O, P      | Paste Cell                |
 | Ctrl-Shift-J   | Extend Marked Cells Below |
 | Ctrl-Shift-K   | Extend Marked Cells Above |
-| Ctrl-O, O      | Insert Cell Below         |
-| Ctrl-O, Ctrl-O | Insert Cell Above         |
 | Ctrl-J         | Select Cell Below         |
 | Ctrl-K         | Select Cell Above         |
 | Ctrl-O, G      | Select First Cell         |
 | Ctrl-O, Ctrl-G | Select Last Cell          |
+| Ctrl-O, O      | Insert Cell Below         |
+| Ctrl-O, Ctrl-O | Insert Cell Above         |
+| Ctrl-O, D      | Delete (Cut) Cell         |
+| Ctrl-O, Y      | Yank (Copy) Cell          |
+| Ctrl-O, P      | Paste Cell Below          |
 | Ctrl-E         | Move Cell Down            |
 | Ctrl-Y         | Move Cell Up              |
+| Ctrl-O, U      | Undo Cell Action          |
 | Ctrl-O, Z, Z   | Center Cell               |
 | Ctrl-G         | Show Tooltip              |
 | Cmd/Ctrl-1     | Change to Code Cell       |
@@ -90,15 +90,15 @@ Shortcuts that this extension introduces:
 | ------- | ------------------- |
 | G, G    | Select First Cell   |
 | Shift-G | Select Last Cell    |
-| D, D    | Delete Cell         |
-| Y, Y    | Yank (Copy) Cell    |
-| P       | Paste Cell          |
-| Shift-P | Paste Cell Above    |
-| O       | Insert Cell         |
+| O       | Insert Cell Below   |
 | Shift-O | Insert Cell Above   |
-| U       | Undo Cell Action    |
+| D, D    | Delete (Cut) Cell   |
+| Y, Y    | Yank (Copy) Cell    |
+| P       | Paste Cell Below    |
+| Shift-P | Paste Cell Above    |
 | Ctrl-E  | Move Cells Down     |
 | Ctrl-Y  | Move Cells Up       |
+| U       | Undo Cell Action    |
 | Z, Z    | Center Cell         |
 | Z, C    | Hide Code Cell      |
 | Z, O    | Show Code Cell      |

--- a/README.md
+++ b/README.md
@@ -16,14 +16,14 @@ Notebook cell vim bindings
 
 ## Modes
 
-Like vim, Jupyterlab has a distinction between edit mode and command mode. Jupyterlab Command mode is when the cursor is not in a specific cell, and edit mode when typing in a cell.
+Like vim, Jupyterlab has a distinction between Edit mode and Command mode. Jupyterlab is in Command mode when the cursor is not in a specific cell, and it is in Edit mode when typing in a cell.
 
-This extension combines the Jupyterlab (Edit and Command) modes with the standard vim modes (Normal, Insert, Visual). So the set of modes now looks like:
+This extension combines the Jupyterlab (Edit and Command) modes with the standard vim modes (Normal, Insert and Visual). So the set of modes now looks like:
 
-1. Jupyterlab Command Mode
-2. Jupyterlab Edit Mode
-   - Insert
+1. Jupyterlab Command mode
+2. Jupyterlab Edit mode
    - Normal
+   - Insert
    - Visual
 
 See [key bindings for switching between modes](#switching-between-modes).
@@ -44,45 +44,45 @@ mamba install -c conda-forge jupyterlab_vim
 
 To learn how to modify key bindings see the [modify-keybinds.md](modify-keybinds.md) file.
 
-**Please note that all keys are lowercase unless `Shift` is explicitly indicated.**
-For example, `Y, Y` is two lowercase `y`s, `Shift-Y, Y` is one uppercase `Y` followed by a lowercase `y`.
+**Please note that all keys are lowercase unless <kbd>Shift</kbd> is explicitly indicated.**
+For example, <kbd>Y, Y</kbd> is two lowercase <kbd>y</kbd>s, and <kbd>Shift-Y, Y</kbd> is one uppercase <kbd>Y</kbd> followed by a lowercase <kbd>y</kbd>.
 
-Shortcuts this extension introduces:
+Shortcuts that this extension introduces:
 
 ### Vim Ex commands
 
 | Command  | Action                     |
 | -------- | -------------------------- |
 | :w[rite] | Save Notebook              |
-| :q[uit]  | Enter Jupyter command mode |
+| :q[uit]  | Enter Jupyter Command Mode |
 
 ### Vim command bindings
 
-| Chord           | Action                    |
-| --------------- | ------------------------- |
-| Ctrl-O, U       | Undo Cell Action          |
-| -               | Split Cell at Cursor      |
-| Ctrl-O, -       | Split Cell at Cursor      |
-| Ctrl-O, D       | Cut Cell                  |
-| Ctrl-O, Y       | Copy Cell                 |
-| Ctrl-O, P       | Paste Cell                |
-| Ctrl-Shift-J    | Extend Marked Cells Below |
-| Ctrl-Shift-K    | Extend Marked Cells Above |
-| Ctrl-O, O       | Insert Cell Below         |
-| Ctrl-O, Ctrl-O  | Insert Cell Above         |
-| Ctrl-J          | Select Cell Below         |
-| Ctrl-K          | Select Cell Above         |
-| Ctrl-O, G       | Select First Cell         |
-| Ctrl-O, Ctrl-G  | Select Last Cell          |
-| Ctrl-E          | Move Cell Down            |
-| Ctrl-Y          | Move Cell Up              |
-| Ctrl-O, Z, Z    | Center Cell               |
-| Ctrl-G          | Show Tooltip              |
-| Command/Ctrl-1  | Code Cell Mode            |
-| Command/Ctrl-2  | Markdown Cell Mode        |
-| Command/Ctrl-3  | Raw Cell Mode             |
-| Shift-Escape    | Leave Vim Mode            |
-| Escape, Ctrl-\[ | Exit Vim Insert Mode      |
+| Chord          | Action                    |
+| -------------- | ------------------------- |
+| Ctrl-O, U      | Undo Cell Action          |
+| -              | Split Cell at Cursor      |
+| Ctrl-O, -      | Split Cell at Cursor      |
+| Ctrl-O, D      | Cut Cell                  |
+| Ctrl-O, Y      | Copy Cell                 |
+| Ctrl-O, P      | Paste Cell                |
+| Ctrl-Shift-J   | Extend Marked Cells Below |
+| Ctrl-Shift-K   | Extend Marked Cells Above |
+| Ctrl-O, O      | Insert Cell Below         |
+| Ctrl-O, Ctrl-O | Insert Cell Above         |
+| Ctrl-J         | Select Cell Below         |
+| Ctrl-K         | Select Cell Above         |
+| Ctrl-O, G      | Select First Cell         |
+| Ctrl-O, Ctrl-G | Select Last Cell          |
+| Ctrl-E         | Move Cell Down            |
+| Ctrl-Y         | Move Cell Up              |
+| Ctrl-O, Z, Z   | Center Cell               |
+| Ctrl-G         | Show Tooltip              |
+| Command/Ctrl-1 | Code Cell Mode            |
+| Command/Ctrl-2 | Markdown Cell Mode        |
+| Command/Ctrl-3 | Raw Cell Mode             |
+| Shift-Esc      | Exit to Command Mode      |
+| Esc or Ctrl-\[ | Exit Current Mode        |
 
 ### Jupyter command bindings
 
@@ -115,10 +115,10 @@ Shortcuts this extension introduces:
     - <kbd>Shift</kbd>+<kbd>Esc</kbd>
     - <kbd>Esc</kbd> or <kbd>Ctrl</kbd>+<kbd>[</kbd>, if the "Enable `Esc` and `Ctrl-[` leaving vim Normal mode to Jupyter Command mode" option is enabled (on by default). To disable the option, go to Settings menu → Settings Editor → Notebook Vim.
   - To enter Insert mode from Normal mode, use one of the insert commmands, such as <kbd>i</kbd>, <kbd>I</kbd>, <kbd>a</kbd>, <kbd>A</kbd>, <kbd>o</kbd>, <kbd>O</kbd>, <kbd>c</kbd>, <kbd>C</kbd>, <kbd>s</kbd> or <kbd>S</kbd>.
-  - To enter Visual Mode from Normal mode, use one of the visual commands, such as <kbd>v</kbd>, <kbd>V</kbd> or <kbd>Ctrl</kbd>+<kbd>V</kbd>.
-- From Insert or Visual modes:
-  - To leave Insert or Visual modes to Normal Mode, press <kbd>Esc</kbd> or <kbd>Ctrl</kbd>+<kbd>[</kbd>.
-  - To leave Insert or Visual modes to Command Mode, press <kbd>Shift</kbd>+<kbd>Esc</kbd>.
+  - To enter Visual mode from Normal mode, use one of the visual commands, such as <kbd>v</kbd>, <kbd>V</kbd> or <kbd>Ctrl</kbd>+<kbd>V</kbd>.
+- From Insert or Visual mode:
+  - To leave Insert or Visual mode to Normal mode, press <kbd>Esc</kbd> or <kbd>Ctrl</kbd>+<kbd>[</kbd>.
+  - To leave Insert or Visual mode to Command mode, press <kbd>Shift</kbd>+<kbd>Esc</kbd>.
 
 ## Special Thanks
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ mamba install -c conda-forge jupyterlab_vim
 To learn how to modify key bindings see the [modify-keybinds.md](modify-keybinds.md) file.
 
 **Please note that all keys are lowercase unless <kbd>Shift</kbd> is explicitly indicated.**
-For example, `Y, Y` means press lowercase <kbd>y</kbd> twice, while `Shift-Y, Y` means press <kbd>Shift</kbd>+<kbd>y</kbd> followed by a lowercase <kbd>y</kbd>.
+For example, "<kbd>Y</kbd>, <kbd>Y</kbd>" means pressing lowercase <kbd>y</kbd> twice, while "<kbd>Shift-Y</kbd>, <kbd>Y</kbd>" means pressing <kbd>Shift</kbd>+<kbd>y</kbd> followed by a lowercase <kbd>y</kbd>.
 
 Shortcuts that this extension introduces:
 
@@ -56,9 +56,9 @@ Shortcuts that this extension introduces:
 | :w[rite] | Save Notebook              |
 | :q[uit]  | Enter Jupyter Command Mode |
 
-### Vim command bindings
+### Vim (Jupyter Edit mode) bindings
 
-| Chord          | Action                    |
+| Shortcut       | Action                    |
 | -------------- | ------------------------- |
 | -              | Split Cell at Cursor      |
 | Ctrl-O, -      | Split Cell at Cursor      |
@@ -84,26 +84,26 @@ Shortcuts that this extension introduces:
 | Shift-Esc      | Exit to Command Mode      |
 | Esc or Ctrl-\[ | Exit Current Mode         |
 
-### Jupyter command bindings
+### Jupyter Command mode bindings
 
-| Chord   | Action              |
-| ------- | ------------------- |
-| G, G    | Select First Cell   |
-| Shift-G | Select Last Cell    |
-| O       | Insert Cell Below   |
-| Shift-O | Insert Cell Above   |
-| D, D    | Delete (Cut) Cell   |
-| Y, Y    | Yank (Copy) Cell    |
-| P       | Paste Cell Below    |
-| Shift-P | Paste Cell Above    |
-| Ctrl-E  | Move Cells Down     |
-| Ctrl-Y  | Move Cells Up       |
-| U       | Undo Cell Action    |
-| Z, Z    | Center Cell         |
-| Z, C    | Hide Code Cell      |
-| Z, O    | Show Code Cell      |
-| Z, M    | Hide All Code Cells |
-| Z, R    | Show All Code Cells |
+| Shortcut | Action              |
+| -------- | ------------------- |
+| G, G     | Select First Cell   |
+| Shift-G  | Select Last Cell    |
+| O        | Insert Cell Below   |
+| Shift-O  | Insert Cell Above   |
+| D, D     | Delete (Cut) Cell   |
+| Y, Y     | Yank (Copy) Cell    |
+| P        | Paste Cell Below    |
+| Shift-P  | Paste Cell Above    |
+| Ctrl-E   | Move Cells Down     |
+| Ctrl-Y   | Move Cells Up       |
+| U        | Undo Cell Action    |
+| Z, Z     | Center Cell         |
+| Z, C     | Hide Code Cell      |
+| Z, O     | Show Code Cell      |
+| Z, M     | Hide All Code Cells |
+| Z, R     | Show All Code Cells |
 
 ### Switching between modes
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ mamba install -c conda-forge jupyterlab_vim
 To learn how to modify key bindings see the [modify-keybinds.md](modify-keybinds.md) file.
 
 **Please note that all keys are lowercase unless <kbd>Shift</kbd> is explicitly indicated.**
-For example, <kbd>Y, Y</kbd> is two lowercase <kbd>y</kbd>s, and <kbd>Shift-Y, Y</kbd> is one uppercase <kbd>Y</kbd> followed by a lowercase <kbd>y</kbd>.
+For example, `Y, Y` means press lowercase <kbd>y</kbd> twice, while `Shift-Y, Y` means press <kbd>Shift</kbd>+<kbd>y</kbd> followed by a lowercase <kbd>y</kbd>.
 
 Shortcuts that this extension introduces:
 
@@ -78,9 +78,9 @@ Shortcuts that this extension introduces:
 | Ctrl-Y         | Move Cell Up              |
 | Ctrl-O, Z, Z   | Center Cell               |
 | Ctrl-G         | Show Tooltip              |
-| Command/Ctrl-1 | Code Cell Mode            |
-| Command/Ctrl-2 | Markdown Cell Mode        |
-| Command/Ctrl-3 | Raw Cell Mode             |
+| Cmd/Ctrl-1     | Change to Code Cell       |
+| Cmd/Ctrl-2     | Change to Markdown Cell   |
+| Cmd/Ctrl-3     | Change to Raw Cell        |
 | Shift-Esc      | Exit to Command Mode      |
 | Esc or Ctrl-\[ | Exit Current Mode         |
 
@@ -114,8 +114,8 @@ Shortcuts that this extension introduces:
   - To leave Normal mode to Command mode, several options are available:
     - <kbd>Shift</kbd>+<kbd>Esc</kbd>
     - <kbd>Esc</kbd> or <kbd>Ctrl</kbd>+<kbd>[</kbd>, if the "Enable `Esc` and `Ctrl-[` leaving vim Normal mode to Jupyter Command mode" option is enabled (on by default). To disable the option, go to Settings menu → Settings Editor → Notebook Vim.
-  - To enter Insert mode from Normal mode, use one of the insert commmands, such as <kbd>i</kbd>, <kbd>I</kbd>, <kbd>a</kbd>, <kbd>A</kbd>, <kbd>o</kbd>, <kbd>O</kbd>, <kbd>c</kbd>, <kbd>C</kbd>, <kbd>s</kbd> or <kbd>S</kbd>.
-  - To enter Visual mode from Normal mode, use one of the visual commands, such as <kbd>v</kbd>, <kbd>V</kbd> or <kbd>Ctrl</kbd>+<kbd>V</kbd>.
+  - To enter Insert mode from Normal mode, use one of the insert commmands, such as <kbd>i</kbd>, <kbd>Shift</kbd>+<kbd>i</kbd>, <kbd>a</kbd>, <kbd>Shift</kbd>+<kbd>a</kbd>, <kbd>o</kbd>, <kbd>Shift</kbd>+<kbd>o</kbd>, <kbd>c</kbd>, <kbd>Shift</kbd>+<kbd>c</kbd>, <kbd>s</kbd> or <kbd>Shift</kbd>+<kbd>s</kbd>.
+  - To enter Visual mode from Normal mode, use one of the visual commands, such as <kbd>v</kbd>, <kbd>Shift</kbd>+<kbd>v</kbd> or <kbd>Ctrl</kbd>+<kbd>v</kbd>.
 - From Insert or Visual mode:
   - To leave Insert or Visual mode to Normal mode, press <kbd>Esc</kbd> or <kbd>Ctrl</kbd>+<kbd>[</kbd>.
   - To leave Insert or Visual mode to Command mode, press <kbd>Shift</kbd>+<kbd>Esc</kbd>.


### PR DESCRIPTION
- Key binding lists
  - [x] Fix the "<kbd>Esc, Ctrl-[</kbd>" key binding, which would have meant pressing these in succession, to say "<kbd>Esc</kbd> **or** <kbd>Ctrl-[</kbd>".
  - [x] Reword the descriptions of "<kbd>Shift-Esc</kbd>" and "<kbd>Esc</kbd> or <kbd>Ctrl-[</kbd>" to be more accurate.
  - [x] Reword the descriptions for changing cell type to be similar to those in JupyterLab.
  - [x] Consistency in abbreviations and capitalization
    - [x] <kbd>Esc</kbd>
    - [x] <kbd>Cmd</kbd>
  - [x] Reorder vim bindings and Jupyter command bindings to put the corresponding bindings in the same order.
- Elsewhere
  - [x] Fix grammar in various places.
  - [x] Flip order of Normal and Insert modes in the mode list, based on the order that they are entered relative to Command mode, i.e., how they would be ordered in a flow diagram.
  - [x] Change the key binding explanation to use `<kbd>` tags based on semantics. (However, to retain consistency with the style in vim help files, the key bindings in the lists still use hyphens between the keys.)
  - [x] Uniformly make mode names capitalized and "mode" itself lowercase in paragraph text. (Key binding descriptions have been left as title case only to minimize change. I wouldn't be opposed to making these sentence case.)